### PR TITLE
Create different number of mesh nodes in x- and y-direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Create different number of mesh nodes in x- and y-direction.
+  [\#21](https://github.com/mllam/weather-model-graphs/pull/21)
+  @joeloskarsson
+
 - Changed the `refinement_factor` argument into two: a `grid_refinement_factor` and a `level_refinement_factor`.
   [\#19](https://github.com/mllam/weather-model-graphs/pull/19)
   @joeloskarsson

--- a/src/weather_model_graphs/create/mesh/kinds/flat.py
+++ b/src/weather_model_graphs/create/mesh/kinds/flat.py
@@ -57,15 +57,17 @@ def create_flat_multiscale_mesh_graph(
     level_offset = level_refinement_factor // 2
     for lev in range(1, len(G_all_levels)):
         nodes = list(G_all_levels[lev - 1].nodes)
-        n = int(np.sqrt(len(nodes)))
+        # Last nodes always has pos (nx-1, ny-1)
+        num_nodes_x = nodes[-1][0] + 1
+        num_nodes_y = nodes[-1][1] + 1
         ij = (
             np.array(nodes)
-            .reshape((n, n, 2))[
+            .reshape((num_nodes_x, num_nodes_y, 2))[
                 level_offset::level_refinement_factor,
                 level_offset::level_refinement_factor,
                 :,
             ]
-            .reshape(int(n / level_refinement_factor) ** 2, 2)
+            .reshape(int(num_nodes_x * num_nodes_y / (level_refinement_factor**2)), 2)
         )
         ij = [tuple(x) for x in ij]
         G_all_levels[lev] = networkx.relabel_nodes(

--- a/src/weather_model_graphs/create/mesh/mesh.py
+++ b/src/weather_model_graphs/create/mesh/mesh.py
@@ -106,25 +106,39 @@ def create_multirange_2d_mesh_graphs(
         of the mesh within each level
     """
     # max_coord/(grid_refinement_factor*level_refinement_factor^mesh_levels) = 1
-    mesh_levels = int(
-        (np.log(max(xy.shape)) - np.log(grid_refinement_factor))
+    # Compute the size along y and x direction of area to cover with graph
+    coord_extent = np.max(xy, axis=(1, 2)) - np.min(xy, axis=(1, 2))  # (2,)
+
+    # Find the number of mesh levels possible in x- and y-direction,
+    # and the number of leaf nodes that would correspond to
+    max_mesh_levels = (
+        (np.log(coord_extent) - np.log(grid_refinement_factor))
         / np.log(level_refinement_factor)
-    )
+    ).astype(
+        int
+    )  # (2,)
     nleaf = grid_refinement_factor * (
-        level_refinement_factor**mesh_levels
-    )  # leaves at the bottom = nleaf**2
+        level_refinement_factor**max_mesh_levels
+    )  # leaves at the bottom in each direction, if using max_mesh_levels
+
+    # As we can not instantiate different number of mesh levels in each
+    # direction, create mesh levels corresponding to the minimum of the two
+    mesh_levels_to_create = max_mesh_levels.min()
 
     if max_num_levels:
         # Limit the levels in mesh graph
-        mesh_levels = min(mesh_levels, max_num_levels)
+        mesh_levels_to_create = min(mesh_levels_to_create, max_num_levels)
 
-    logger.debug(f"mesh_levels: {mesh_levels}, nleaf: {nleaf}")
+    logger.debug(f"mesh_levels: {mesh_levels_to_create}, nleaf: {nleaf}")
 
     # multi resolution tree levels
     G_all_levels = []
-    for lev in range(mesh_levels):  # 0-index mesh levels
-        n = int(nleaf / (grid_refinement_factor * (level_refinement_factor**lev)))
-        g = create_single_level_2d_mesh_graph(xy, n, n)
+    for lev in range(mesh_levels_to_create):  # 0-index mesh levels
+        # Compute number of nodes on level separate for each direction
+        nodes_x, nodes_y = (
+            nleaf / (grid_refinement_factor * (level_refinement_factor**lev))
+        ).astype(int)
+        g = create_single_level_2d_mesh_graph(xy, nodes_x, nodes_y)
         # Add level information to nodes, edges and full graph
         for node in g.nodes:
             g.nodes[node]["level"] = lev

--- a/src/weather_model_graphs/create/mesh/mesh.py
+++ b/src/weather_model_graphs/create/mesh/mesh.py
@@ -94,10 +94,11 @@ def create_multirange_2d_mesh_graphs(
     max_num_levels : int
         Number of edge-distance levels in mesh graph
     xy : np.ndarray
-        Grid point coordinates
+        Grid point coordinates, shaped [2, M, N]
     refinement_factor : int
         Degree of refinement between successive mesh graphs, the number of nodes
-        grows by refinement_factor**2 between successive mesh graphs
+        grows by approximately refinement_factor**2 between successive
+        mesh graphs.
 
     Returns
     -------
@@ -105,12 +106,13 @@ def create_multirange_2d_mesh_graphs(
         List of networkx graphs for each level representing the connectivity
         of the mesh within each level
     """
-    # max_coord/(grid_refinement_factor*level_refinement_factor^mesh_levels) = 1
-    # Compute the size along y and x direction of area to cover with graph
-    coord_extent = np.max(xy, axis=(1, 2)) - np.min(xy, axis=(1, 2))  # (2,)
+    # Compute the size (grid nodes) along x and y direction of area
+    # to cover with graph
+    coord_extent = np.array((xy.shape[2], xy.shape[1]))
 
     # Find the number of mesh levels possible in x- and y-direction,
     # and the number of leaf nodes that would correspond to
+    # max_coord/(grid_refinement_factor*level_refinement_factor^mesh_levels) = 1
     max_mesh_levels = (
         (np.log(coord_extent) - np.log(grid_refinement_factor))
         / np.log(level_refinement_factor)

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -16,6 +16,14 @@ def _create_fake_xy(N=10):
     return xy
 
 
+def _create_rectangular_fake_xy(Nx=10, Ny=20):
+    x = np.linspace(0, 1, Nx)
+    y = np.linspace(0, 1, Ny)
+    xy = np.meshgrid(x, y)
+    xy = np.stack(xy, axis=0)
+    return xy
+
+
 def test_create_single_level_mesh_graph():
     xy = _create_fake_xy(N=4)
     mesh_graph = wmg.create.mesh.create_single_level_2d_mesh_graph(xy=xy, nx=5, ny=5)
@@ -94,3 +102,21 @@ def test_create_graph_generic(m2g_connectivity, g2m_connectivity, m2m_connectivi
                     isinstance(graph, nx.DiGraph) for graph in graph_components.values()
                 )
                 assert set(graph_components.keys()) == {"m2m", "m2g", "g2m"}
+
+
+@pytest.mark.parametrize("kind", ["graphcast", "keisler", "oskarsson_hierarchical"])
+def test_create_rectangular_graph(kind):
+    """
+    Tests that graphs can be created for non-square areas, both thin and wide
+    """
+    # Test thin
+    xy = _create_rectangular_fake_xy(Nx=20, Ny=64)
+    fn_name = f"create_{kind}_graph"
+    fn = getattr(wmg.create.archetype, fn_name)
+    fn(xy_grid=xy, grid_refinement_factor=2)
+
+    # Test wide
+    xy = _create_rectangular_fake_xy(Nx=64, Ny=20)
+    fn_name = f"create_{kind}_graph"
+    fn = getattr(wmg.create.archetype, fn_name)
+    fn(xy_grid=xy, grid_refinement_factor=2)


### PR DESCRIPTION
## Describe your changes

Currently the 2d multirange graphs created for multiscale and hierarchical graphs are restricted to laying  out mesh nodes in an $n \times n$ grid. This is suitable for forecasting areas that are roughly square, but a poor choice for rectangular areas with a large difference between it's height and width.

This PR updates the way multiscale and hierarchical graphs are created to compute the refinement (or equivalently the number of mesh nodes at each level) separately in the x- and y-directions. The result of this is probably best understood by an example:

Here a mesh graph is created for an area with $10 \times 30$ grid nodes. We are making a hierarchical graph, plotting only nodes. Grid nodes have level -1. Before this change the graph would look like this:

![hi_old](https://github.com/user-attachments/assets/c8a4cb62-4f88-444d-8e41-d1fac5a6921b)

Note that for level 0 there are 8 mesh nodes created in each direction, although this is way too many for the y-direction. This results in very short distances within the mesh in the y-direction compared to the x-direction. The higher levels share the same problem.

After this change the same graph looks like this:

![hi_new](https://github.com/user-attachments/assets/bbb1ff17-e81c-41ee-8e56-d875bd1db442)

Now the distance between mesh nodes is roughly the same in the x- and y-direction. Note that with this change we can no longer fit 3 mesh levels. This is actually desirable behavior, as the height of this area is actually too small to properly fit 3 levels.

This change builds upon #19 , and should be merged after that.

## Issue Link

This provides some potential answers to #2. If those outstanding questions do not require further discussion I think this can close #2.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [x] I have updated the documentation to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [x] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
