### PR TITLE
Fix wrong number of mesh levels when grid is multiple of refinement factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix wrong number of mesh levels when grid is multiple of refinement factor
+  [\#26](https://github.com/mllam/weather-model-graphs/pull/26)
+  @joeloskarsson
+
 - Create different number of mesh nodes in x- and y-direction.
   [\#21](https://github.com/mllam/weather-model-graphs/pull/21)
   @joeloskarsson

--- a/src/weather_model_graphs/create/mesh/mesh.py
+++ b/src/weather_model_graphs/create/mesh/mesh.py
@@ -113,12 +113,14 @@ def create_multirange_2d_mesh_graphs(
     # Find the number of mesh levels possible in x- and y-direction,
     # and the number of leaf nodes that would correspond to
     # max_coord/(grid_refinement_factor*level_refinement_factor^mesh_levels) = 1
-    max_mesh_levels = (
-        (np.log(coord_extent) - np.log(grid_refinement_factor))
-        / np.log(level_refinement_factor)
-    ).astype(
-        int
-    )  # (2,)
+    max_mesh_levels_float = (
+        np.log(coord_extent) - np.log(grid_refinement_factor)
+    ) / np.log(level_refinement_factor)
+
+    # Need to add a small epsilon before rounding to int, due to numerical
+    # issues with the computation above
+    eps = 1e-8
+    max_mesh_levels = (max_mesh_levels_float + eps).astype(int)  # (2,)
     nleaf = grid_refinement_factor * (
         level_refinement_factor**max_mesh_levels
     )  # leaves at the bottom in each direction, if using max_mesh_levels

--- a/src/weather_model_graphs/create/mesh/mesh.py
+++ b/src/weather_model_graphs/create/mesh/mesh.py
@@ -117,7 +117,7 @@ def create_multirange_2d_mesh_graphs(
         np.log(coord_extent) - np.log(grid_refinement_factor)
     ) / np.log(level_refinement_factor)
 
-    # Need to add a small epsilon before rounding to int, due to numerical
+    # Need to add a small epsilon before flooring to int, due to numerical
     # issues with the computation above
     eps = 1e-8
     max_mesh_levels = (max_mesh_levels_float + eps).astype(int)  # (2,)

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -120,3 +120,23 @@ def test_create_rectangular_graph(kind):
     fn_name = f"create_{kind}_graph"
     fn = getattr(wmg.create.archetype, fn_name)
     fn(xy_grid=xy, grid_refinement_factor=2)
+
+
+@pytest.mark.parametrize("grid_refinement_factor", (2, 3))
+@pytest.mark.parametrize("level_refinement_factor", (2, 3, 5))
+def test_create_exact_refinement(grid_refinement_factor, level_refinement_factor):
+    """
+    This test is to check that it is possible to create graph hierarchies when
+    the refinement factors are an exact multiple of the number of nodes. In these
+    situations it should be possible to create multi-level graphs, but it was not
+    earlier due to numerical issues.
+    """
+    N = grid_refinement_factor * (level_refinement_factor**2)
+    xy = _create_rectangular_fake_xy(Nx=N, Ny=N)
+
+    # Build hierarchical graph, should have 2 levels and not give error
+    wmg.create.archetype.create_oskarsson_hierarchical_graph(
+        xy,
+        grid_refinement_factor=grid_refinement_factor,
+        level_refinement_factor=level_refinement_factor,
+    )


### PR DESCRIPTION
## Describe your changes

There is currently a bug where you can not make hierarchical graphs if the grid dimensions are an exact multiple of the refinement factor. This is best illustrated with an example: 

* If you have a 27 x 27 grid
* grid_refinement_factor=3 and level_refinement_factor=3

Then you should be able to have a first mesh level of 9x9 and a second of 3x3 mesh nodes. This does currently not work, as the code return that the maximum number of possible mesh levels is 1, rather than 2.

We tracked down this issue to the casting to int in 

https://github.com/mllam/weather-model-graphs/blob/1d1407b199e7919c6b8c9bd1f355c4292246eb23/src/weather_model_graphs/create/mesh/mesh.py#L116-L121

Due to the numerical precision of this calculation it sometimes ends up with something like 1.999999999999996 rather than exactly 2. This then gets floored to 1.

This PR fixes this by adding a tiny epsilon before doing this rounding. It also adds a test for this.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] ~I have updated the documentation to cover introduced code changes~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [x] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
