### PR TITLE
Add containing_rectangle graph connection method for m2g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [\#19](https://github.com/mllam/weather-model-graphs/pull/19)
   @joeloskarsson
 
+- Add containing_rectangle graph connection method for m2g edges
+  [\#28](https://github.com/mllam/weather-model-graphs/pull/28)
+  @joeloskarsson
+
 ### Changed
 
 - Create different number of mesh nodes in x- and y-direction.

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -234,6 +234,9 @@ def connect_nodes_across_graphs(
             mesh_node_dx = mesh_node_dx[0]
             mesh_node_dy = mesh_node_dy[0]
 
+        # This function is a filter that applies to edges, represented as vectors (vx, vy) in R^ 2.
+        # The filter is True if |vx| < dx & |vy| < dy, where dx and dy are the distance between
+        # rows and columns in source quadrilateral graph.
         def _edge_filter(edge_prop):
             abs_diffs = np.abs(edge_prop["vdiff"])
             return abs_diffs[0] < mesh_node_dx and abs_diffs[1] < mesh_node_dy

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -212,7 +212,8 @@ def connect_nodes_across_graphs(
         # Connect to all nodes that could potentially be close enough,
         # which is at a relative distance of 1
         rad_graph = connect_nodes_across_graphs(
-            G_source, G_target, method="within_radius", rel_max_dist=1.)
+            G_source, G_target, method="within_radius", rel_max_dist=1.0
+        )
 
         # Filter edges to those that fit within a rectangle of measurements dx,dy
         mesh_node_dx = G_source.graph["dx"]
@@ -228,8 +229,11 @@ def connect_nodes_across_graphs(
             abs_diffs = np.abs(edge_prop["vdiff"])
             return abs_diffs[0] < mesh_node_dx and abs_diffs[1] < mesh_node_dy
 
-        filtered_edges = [(u, v) for u, v, edge_prop in rad_graph.edges(data=True)
-                if _edge_filter(edge_prop)]
+        filtered_edges = [
+            (u, v)
+            for u, v, edge_prop in rad_graph.edges(data=True)
+            if _edge_filter(edge_prop)
+        ]
 
         filtered_graph = rad_graph.edge_subgraph(filtered_edges)
         return filtered_graph

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -208,6 +208,9 @@ def connect_nodes_across_graphs(
             raise Exception(
                 "to use `containing_rectangle` you should not set `max_dist`, `rel_max_dist`or `max_num_neighbours`"
             )
+        assert "dx" in G_source.graph and "dy" in G_source.graph, (
+            "Source graph must have dx and dy properties to connect nodes using method containing_rectangle"
+        )
 
         # Connect to all nodes that could potentially be close enough,
         # which is at a relative distance of 1

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -67,6 +67,9 @@ def create_all_graph_components(
     - "nearest_neighbours": Find the `max_num_neighbours` nearest neighbours in mesh for each node in grid
     - "within_radius": Find all neighbours in mesh within an absolute distance
         of `max_dist` or relative distance of `rel_max_dist` from each node in grid
+    - "containing_rectangle": For each grid node, find the rectangle with 4 mesh nodes as corners
+        such that the grid node is contained within it. Connect these 4 (or less along edges)
+        mesh nodes to the grid node.
     """
     graph_components: dict[networkx.DiGraph] = {}
 
@@ -177,7 +180,10 @@ def connect_nodes_across_graphs(
         - "nearest_neighbour": Find the nearest neighbour in `G_target` for each node in `G_source`
         - "nearest_neighbours": Find the `max_num_neighbours` nearest neighbours in `G_target` for each node in `G_source`
         - "within_radius": Find all neighbours in `G_target` within a distance of `max_dist` from each node in `G_source`
-        - "containing_rectangle": TODO
+        - "containing_rectangle": For each node in `G_target`, find the rectangle in `G_source`
+            with 4 nodes as corners such that the `G_target` node is contained within it.
+            Connect these 4 (or less along edges) corner nodes to the `G_target` node.
+            Requires that `G_source` has dx and dy properties, i.e. is a quadrilateral mesh graph.
     max_dist : float
         Maximum distance to search for neighbours in `G_target` for each node in `G_source`
     max_num_neighbours : int

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -214,9 +214,9 @@ def connect_nodes_across_graphs(
             raise Exception(
                 "to use `containing_rectangle` you should not set `max_dist`, `rel_max_dist`or `max_num_neighbours`"
             )
-        assert "dx" in G_source.graph and "dy" in G_source.graph, (
-            "Source graph must have dx and dy properties to connect nodes using method containing_rectangle"
-        )
+        assert (
+            "dx" in G_source.graph and "dy" in G_source.graph
+        ), "Source graph must have dx and dy properties to connect nodes using method containing_rectangle"
 
         # Connect to all nodes that could potentially be close enough,
         # which is at a relative distance of 1

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -186,6 +186,9 @@ def connect_nodes_across_graphs(
             Requires that `G_source` has dx and dy properties, i.e. is a quadrilateral mesh graph.
     max_dist : float
         Maximum distance to search for neighbours in `G_target` for each node in `G_source`
+    rel_max_dist : float
+        Maximum distance to search for neighbours in `G_target` for each node in `G_source`,
+        relative to longest edge in (bottom level of) `G_source` and `G_target`.
     max_num_neighbours : int
         Maximum number of neighbours to search for in `G_target` for each node in `G_source`
 
@@ -219,7 +222,8 @@ def connect_nodes_across_graphs(
         ), "Source graph must have dx and dy properties to connect nodes using method containing_rectangle"
 
         # Connect to all nodes that could potentially be close enough,
-        # which is at a relative distance of 1
+        # which is at a relative distance of 1. This relative distance is equal
+        # to the diagonal of one rectangle.
         rad_graph = connect_nodes_across_graphs(
             G_source, G_target, method="within_radius", rel_max_dist=1.0
         )

--- a/src/weather_model_graphs/create/mesh/kinds/hierarchical.py
+++ b/src/weather_model_graphs/create/mesh/kinds/hierarchical.py
@@ -121,4 +121,8 @@ def create_hierarchical_multiscale_mesh_graph(
 
     G_m2m = networkx.compose_all([G_all_levels, G_up_all, G_down_all])
 
+    # add dx and dy to graph
+    for prop in ("dx", "dy"):
+        G_m2m.graph[prop] = {i: g.graph[prop] for i, g in enumerate(Gs_all_levels)}
+
     return G_m2m

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -49,7 +49,7 @@ def test_create_graph_archetype(kind):
 
 
 # list the connectivity options for g2m and m2g and the kwargs to test
-G2M_M2G_CONNECTIVITY_OPTIONS = dict(
+G2M_CONNECTIVITY_OPTIONS = dict(
     nearest_neighbour=[],
     nearest_neighbours=[dict(max_num_neighbours=4), dict(max_num_neighbours=8)],
     within_radius=[
@@ -58,8 +58,10 @@ G2M_M2G_CONNECTIVITY_OPTIONS = dict(
         dict(rel_max_dist=0.51),
         dict(rel_max_dist=1.0),
     ],
-    containing_rectangle=[dict()],
 )
+# containing_rectangle option should only be used for m2g
+M2G_CONNECTIVITY_OPTIONS = G2M_CONNECTIVITY_OPTIONS.copy()
+M2G_CONNECTIVITY_OPTIONS["containing_rectangle"] = [dict()]
 
 # list the connectivity options for m2m and the kwargs to test
 M2M_CONNECTIVITY_OPTIONS = dict(
@@ -75,14 +77,14 @@ M2M_CONNECTIVITY_OPTIONS = dict(
 )
 
 
-@pytest.mark.parametrize("g2m_connectivity", G2M_M2G_CONNECTIVITY_OPTIONS.keys())
-@pytest.mark.parametrize("m2g_connectivity", G2M_M2G_CONNECTIVITY_OPTIONS.keys())
+@pytest.mark.parametrize("g2m_connectivity", G2M_CONNECTIVITY_OPTIONS.keys())
+@pytest.mark.parametrize("m2g_connectivity", M2G_CONNECTIVITY_OPTIONS.keys())
 @pytest.mark.parametrize("m2m_connectivity", M2M_CONNECTIVITY_OPTIONS.keys())
 def test_create_graph_generic(m2g_connectivity, g2m_connectivity, m2m_connectivity):
     xy = _create_fake_xy(N=32)
 
-    for g2m_kwargs in G2M_M2G_CONNECTIVITY_OPTIONS[g2m_connectivity]:
-        for m2g_kwargs in G2M_M2G_CONNECTIVITY_OPTIONS[m2g_connectivity]:
+    for g2m_kwargs in G2M_CONNECTIVITY_OPTIONS[g2m_connectivity]:
+        for m2g_kwargs in M2G_CONNECTIVITY_OPTIONS[m2g_connectivity]:
             for m2m_kwargs in M2M_CONNECTIVITY_OPTIONS[m2m_connectivity]:
                 graph = wmg.create.create_all_graph_components(
                     xy=xy,

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -58,6 +58,7 @@ G2M_M2G_CONNECTIVITY_OPTIONS = dict(
         dict(rel_max_dist=0.51),
         dict(rel_max_dist=1.0),
     ],
+    containing_rectangle=[dict()]
 )
 
 # list the connectivity options for m2m and the kwargs to test

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -58,7 +58,7 @@ G2M_M2G_CONNECTIVITY_OPTIONS = dict(
         dict(rel_max_dist=0.51),
         dict(rel_max_dist=1.0),
     ],
-    containing_rectangle=[dict()]
+    containing_rectangle=[dict()],
 )
 
 # list the connectivity options for m2m and the kwargs to test


### PR DESCRIPTION
## Describe your changes
This PR introduces a new method for connecting a mesh graph to the grid.

### Background
In earlier work we have used 4-nearest-neighbors (4nn) to create the m2g connection. This is not terrible, but has its issues (see  below), especially for grid cells along the edges (outside the area covered by the mesh graph).

Below is an example of how a 4nn m2g graph can look like, with a few edges highlighted

![4nn_problem_illustration](https://github.com/user-attachments/assets/35c2aa5b-672e-41c5-8c5b-af11b5c15840)

* In red: These edges are not really desirable, as they represent strangely long connections in the graph
* In green: This edge does not exist, but it would be natural if it would. This mesh node represents one corner of the "rectangle" made up of 4 mesh nodes.

### containing_rectangle
The 4nn method was somewhat inspired by how m2g is created in GraphCast, where each grid node is projected up to the corresponding triangular face containing it in the mesh graph. The  `containing_rectangle` method is an attempt at achieving something closer to this for regular quadrilateral mesh graphs.

Starting with the end result, m2g edges created using the `containing_rectangle` look like

![cont_example](https://github.com/user-attachments/assets/f0a036ce-c66f-4e49-8c32-126fb4a4207d)

The idea of this method is to similarly to GraphCast find the face of the mesh graph containing each grid node and connect the grid nodes with the edges of that face. Since we currently work with a regular layout for the mesh nodes these faces are rectangles, as illustrated below:

![cont_example_grid](https://github.com/user-attachments/assets/0eda2bfb-606f-46bf-899c-2ac5611cd7fc)

Note that this means that grid nodes along the edges will have less than 4 mesh connections.

### Definition of edge set

The actual definition of this edge set is as follows: Let $d_x$ be the distance between the columns of mesh nodes in the x-direction and similarly $d_y$ in the y-direction. A mesh nodes with coordinates $(x_m, y_m)$ should be connected to a grid node with coordinates $(x_g, y_g)$ if 

$$
(|x_g - x_m| < d_x) ~\\&~ (|y_g - y_m| < d_y).
$$

To avoid having to check all grid and mesh nodes pairwise for the expression above we  in practice start by building a radius graph based on radius $r = \sqrt{d_x^2 + d_y^2}$. This gives an edge set that is a superset of the `containing_rectangle` edge set. We then filter this edge set using the expression above to get the final set of edges. Trying to build a KD-tree using this distance measure directly seemed a bit over-complicated and this two-step method works fast without any issues. 

For now this method is only defined for m2g. It is not entirely clear how to do it for g2m, but it should be possible to extend also to those edges.

## Issue Link

No relevant issue.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [x] I have updated the documentation to cover introduced code changes
  - As far as I see there is no place in the docs where the different graph connections are discussed, so will not add that right now.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [x] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [x] PR is up to date with the base branch
- [ ] the tests pass
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
