### PR TITLE
Make save function more universal to accept any number of 1D or 2D node or edge features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [\#19](https://github.com/mllam/weather-model-graphs/pull/19)
   @joeloskarsson
 
+- `save.to_pyg` can now handle any number of 1D or 2D edge or node features when
+  converting pytorch-geometric `Data` objects to `torch.Tensor` objects.
+
 ### Changed
 
 - Create different number of mesh nodes in x- and y-direction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `save.to_pyg` can now handle any number of 1D or 2D edge or node features when
   converting pytorch-geometric `Data` objects to `torch.Tensor` objects.
+  [\#31](https://github.com/mllam/weather-model-graphs/pull/31)
+  @maxiimilian
 
 ### Changed
 

--- a/src/weather_model_graphs/save.py
+++ b/src/weather_model_graphs/save.py
@@ -9,8 +9,8 @@ from .networkx_utils import MissingEdgeAttributeError, split_graph_by_edge_attri
 
 try:
     import torch
-    import torch_geometric.utils.convert as pyg_convert
     import torch_geometric as pyg
+    import torch_geometric.utils.convert as pyg_convert
 
     HAS_PYG = True
 except ImportError:
@@ -18,12 +18,12 @@ except ImportError:
 
 
 def to_pyg(
-        graph: networkx.DiGraph,
-        output_directory: str,
-        name: str,
-        edge_features: List[str] | None = None,
-        node_features: List[str] | None = None,
-        list_from_attribute=None,
+    graph: networkx.DiGraph,
+    output_directory: str,
+    name: str,
+    edge_features: List[str] | None = None,
+    node_features: List[str] | None = None,
+    list_from_attribute=None,
 ):
     """
     Save the networkx graph to PyTorch Geometric format that matches what the
@@ -86,14 +86,16 @@ def to_pyg(
     def _get_edge_indecies(pyg_g):
         return pyg_g.edge_index
 
-    def _concat_pyg_features(pyg_g: "pyg.data.Data", features: List[str]) -> torch.Tensor:
+    def _concat_pyg_features(
+        pyg_g: "pyg.data.Data", features: List[str]
+    ) -> torch.Tensor:
         """Convert features from pyg.Data object to torch.Tensor.
-        Each feature should be column in the resulting 2D tensor (n_features, n_edges or n_nodes).
+        Each feature should be column in the resulting 2D tensor (n_edges or n_nodes, n_features).
         Note, this function can handle node AND edge features.
         """
         v_concat = []
         for f in features:
-            v = torch.tensor(pyg_g[f])  # make sure we have torch tensor
+            v = pyg_g[f]
             # Convert 1D features into 1xN tensor
             if v.ndim == 1:
                 v = v.unsqueeze(1)
@@ -117,9 +119,13 @@ def to_pyg(
     else:
         pyg_graphs = [pyg_convert.from_networkx(graph)]
 
-    edge_features_values = [_concat_pyg_features(pyg_g, features=edge_features) for pyg_g in pyg_graphs]
+    edge_features_values = [
+        _concat_pyg_features(pyg_g, features=edge_features) for pyg_g in pyg_graphs
+    ]
     edge_indecies = [_get_edge_indecies(pyg_g) for pyg_g in pyg_graphs]
-    node_features_values = [_concat_pyg_features(pyg_g, features=node_features) for pyg_g in pyg_graphs]
+    node_features_values = [
+        _concat_pyg_features(pyg_g, features=node_features) for pyg_g in pyg_graphs
+    ]
 
     if list_from_attribute is None:
         edge_features_values = edge_features_values[0]

--- a/src/weather_model_graphs/visualise/plot_2d.py
+++ b/src/weather_model_graphs/visualise/plot_2d.py
@@ -13,7 +13,7 @@ def nx_draw_with_pos(g, with_labels=False, **kwargs):
     if ax is None:
         _, ax = plt.subplots(figsize=(10, 10))
     networkx.draw_networkx(
-        ax=ax, G=g, pos=pos, hide_ticks=False, with_labels=with_labels, **kwargs
+        ax=ax, G=g, pos=pos, with_labels=with_labels, **kwargs
     )
 
     return ax

--- a/src/weather_model_graphs/visualise/plot_2d.py
+++ b/src/weather_model_graphs/visualise/plot_2d.py
@@ -13,7 +13,7 @@ def nx_draw_with_pos(g, with_labels=False, **kwargs):
     if ax is None:
         _, ax = plt.subplots(figsize=(10, 10))
     networkx.draw_networkx(
-        ax=ax, G=g, pos=pos, with_labels=with_labels, **kwargs
+        ax=ax, G=g, pos=pos, hide_ticks=False, with_labels=with_labels, **kwargs
     )
 
     return ax


### PR DESCRIPTION
## Describe your changes

This pull request contains three changes -- one major and two minor changes.

The major change modifies how edge and node features are converted from `pyg.data.Data` objects into `torch.Tensor`s before saving. If we assume that all node/edge features (features in the following) are numeric, a conversion to float32 will always work. Further, my proposed change assumes that the features can be either 1D (vector of edge lengths) or 2D (node position, vdiff vector between source and target nodes). Based on this, I propose a universal function that reshapes any 1D vector into a 2D column vector, which allows the concatenation of any number of features in a loop. 

Using the new function, we also make the saving of `len` as edge feature explicit by including it in the default `edge_features` list. 

Two minor bugs are fixed:
- Default arguments of functions should not be mutables (list, dicts, any object). See https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments.
- The `hide_ticks` argument for `nx.draw` seems to be deprecated because it caused an error with my networkx v 3.2

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [x] I have updated the documentation to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
