### PR TITLE
Fixed mutable default dictionary bug in base.py, logical error fixed …

### DIFF
--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -36,9 +36,9 @@ def create_all_graph_components(
     m2m_connectivity: str,
     m2g_connectivity: str,
     g2m_connectivity: str,
-    m2m_connectivity_kwargs={},
-    m2g_connectivity_kwargs={},
-    g2m_connectivity_kwargs={},
+    m2m_connectivity_kwargs=None,
+    m2g_connectivity_kwargs=None,
+    g2m_connectivity_kwargs=None,
     coords_crs: pyproj.crs.CRS | None = None,
     graph_crs: pyproj.crs.CRS | None = None,
     decode_mask: Iterable[bool] | None = None,
@@ -95,6 +95,13 @@ def create_all_graph_components(
     `return_components` is a boolean flag, if True the function returns a dict with
     m2g, m2m and g2m as separate graphs. If false returns one combined graph.
     """
+    if m2m_connectivity_kwargs is None:
+        m2m_connectivity_kwargs = {}
+    if m2g_connectivity_kwargs is None:
+        m2g_connectivity_kwargs = {}
+    if g2m_connectivity_kwargs is None:
+        g2m_connectivity_kwargs = {}
+
     graph_components: dict[networkx.DiGraph] = {}
 
     assert (
@@ -102,7 +109,7 @@ def create_all_graph_components(
     ), "Grid node coordinates should be given as an array of shape [num_grid_nodes, 2]."
 
     # Translate between coordinate crs and crs to use for graph creation
-    if coords_crs is None and coords_crs is None:
+    if coords_crs is None and graph_crs is None:
         logger.debug(
             "No `coords_crs` given: Assuming `coords` contains in-projection Cartesian coordinates."
         )

--- a/src/weather_model_graphs/save.py
+++ b/src/weather_model_graphs/save.py
@@ -142,6 +142,7 @@ def to_pyg(
     if list_from_attribute is None:
         edge_features_values = edge_features_values[0]
         edge_indecies = edge_indecies[0]
+        node_features_values = node_features_values[0]
 
     Path(output_directory).mkdir(exist_ok=True, parents=True)
     fp_edge_index = Path(output_directory) / f"{name}_edge_index.pt"


### PR DESCRIPTION
…(replaced coords_crs with graph_crs) and readded node_feature_values for un-wrapping code to make .pt generation indentical

## Describe your changes

**Summary of the changes:**
- **Fixed CRS coordinate bug:** Corrected a copy-paste error in [create_all_graph_components](cci:1://file:///Users/diya/Desktop/mllam/weather-model-graphs/src/weather_model_graphs/create/base.py:33:0-215:16) where `coords_crs` was checked twice instead of `graph_crs`, preventing silent failures during CRS transformation.
- **Removed mutable default arguments:** Replaced mutable dicts `{}` with `None` in the [create_all_graph_components](cci:1://file:///Users/diya/Desktop/mllam/weather-model-graphs/src/weather_model_graphs/create/base.py:33:0-215:16) parameters to prevent shared-state side effects across function calls. 
- **Fixed tensor unwrapping inconsistency:** Added `node_features_values = node_features_values[0]` in `save.to_pyg` when `list_from_attribute=None` to ensure node feature files are saved as raw un-nested Tensors, matching the behavior of the edge feature files.

**Relevant motivation and context:**

While reviewing the codebase, I noticed a few early-stage bugs that could cause silent failures in downstream models or unpredictable graph generation behavior. Fixing these ensures robust CRS behavior, prevents Python mutation side-effects, and standardizes the `.pt` file outputs. 

**List any dependencies that are required for this change:**
- None

## Issue Link

< Link to the relevant issue or task. > (e.g. `closes #00` or `solves #00`)

## Type of change

- [ Yes] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ Yes] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ Yes] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the documentation to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ Yes] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
