### PR TITLE
Fix KDTree scalar return when max_num_neighbours=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix example in README
   [\#38](https://github.com/mllam/weather-model-graphs/pull/38) @leifdenby
 
+- Fix crash in `connect_nodes_across_graphs` when using `method="nearest_neighbours"` with `max_num_neighbours=1`, caused by `KDTree.query` returning a scalar for `k=1`
+  [#90](https://github.com/mllam/weather-model-graphs/pull/90)  @leifdenby
+
 ### Maintenance
 
 - Update github CI actions, including pre-commit action to fix caching issue

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -342,7 +342,7 @@ def connect_nodes_across_graphs(
         def _find_neighbour_node_idxs_in_source_mesh(xy_target):
             neigh_idxs = kdt_s.query(xy_target, max_num_neighbours)[1]
             # KDTree.query returns a scalar when k=1 and a 1-D array when k>1.
-             # np.atleast_1d normalises both cases so the caller can always iterate.
+            # np.atleast_1d normalises both cases so the caller can always iterate.
             return np.atleast_1d(neigh_idxs)
 
     elif method == "within_radius":

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -341,8 +341,8 @@ def connect_nodes_across_graphs(
 
         def _find_neighbour_node_idxs_in_source_mesh(xy_target):
             neigh_idxs = kdt_s.query(xy_target, max_num_neighbours)[1]
-            # KDTree.query returns a scalar when k=1 and a 1-D array when k>1.
-            # np.atleast_1d normalises both cases so the caller can always iterate.
+            #KDTree.query returns a scalar when k=1 and a 1-D array when k>1.
+            #np.atleast_1d normalises both cases so the caller can always iterate.
             return np.atleast_1d(neigh_idxs)
 
     elif method == "within_radius":

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -342,7 +342,6 @@ def connect_nodes_across_graphs(
         def _find_neighbour_node_idxs_in_source_mesh(xy_target):
             neigh_idxs = kdt_s.query(xy_target, max_num_neighbours)[1]
             # KDTree.query returns a scalar when k=1 and a 1-D array when k>1.
-            # np.atleast_1d normalises both cases so the caller can always iterate.
             return np.atleast_1d(neigh_idxs)
 
     elif method == "within_radius":

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -341,7 +341,9 @@ def connect_nodes_across_graphs(
 
         def _find_neighbour_node_idxs_in_source_mesh(xy_target):
             neigh_idxs = kdt_s.query(xy_target, max_num_neighbours)[1]
-            return neigh_idxs
+            # KDTree.query returns a scalar when k=1 and a 1-D array when k>1.
+             # np.atleast_1d normalises both cases so the caller can always iterate.
+            return np.atleast_1d(neigh_idxs)
 
     elif method == "within_radius":
         if max_num_neighbours is not None:

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -341,8 +341,8 @@ def connect_nodes_across_graphs(
 
         def _find_neighbour_node_idxs_in_source_mesh(xy_target):
             neigh_idxs = kdt_s.query(xy_target, max_num_neighbours)[1]
-            #KDTree.query returns a scalar when k=1 and a 1-D array when k>1.
-            #np.atleast_1d normalises both cases so the caller can always iterate.
+            # KDTree.query returns a scalar when k=1 and a 1-D array when k>1.
+            # np.atleast_1d normalises both cases so the caller can always iterate.
             return np.atleast_1d(neigh_idxs)
 
     elif method == "within_radius":


### PR DESCRIPTION
## Changes made -
I fixed a crash in `connect_nodes_across_graphs` when called with `method="nearest_neighbours"` and `max_num_neighbours=1`.

**Root cause:** `scipy.spatial.KDTree.query()` returns different types depending on the value of `k`:
- `k = 1` → scalar (`numpy.int64`)
- `k > 1` → `numpy.ndarray`

The function `_find_neighbour_node_idxs_in_source_mesh` returned the raw query result, which the caller then iterated over. When `k=1`, iterating over a scalar raises:
```
TypeError: 'numpy.int64' object is not iterable
```

**Fix:** Wrap the return value with `np.atleast_1d()` so the result is always iterable, regardless of `k`.

```python
# BEFORE
def _find_neighbour_node_idxs_in_source_mesh(xy_target):
    neigh_idxs = kdt_s.query(xy_target, max_num_neighbours)[1]
    return neigh_idxs

# AFTER
def _find_neighbour_node_idxs_in_source_mesh(xy_target):
    neigh_idxs = kdt_s.query(xy_target, max_num_neighbours)[1]
    # KDTree.query returns a scalar when k=1 and a 1-D array when k>1.
    # np.atleast_1d normalises both cases so the caller can always iterate.
    return np.atleast_1d(neigh_idxs)
```

No dependencies are required for this change.

## Issue Link

Closes #83

## Type of change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review
- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the documentation to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review
- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *fixes*: `connect_nodes_across_graphs` crash when `max_num_neighbours=1` due to `KDTree.query` returning a scalar for `k=1`

## Checklist for assignee
- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
