### PR TITLE
Fix IndexError when visualizung subgraphs with zerod edges or nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix an `IndexError` crash when plotting a graph component with zero edges or zero nodes using `wmg.visualise.nx_draw_with_pos_and_attr`.
+- Fix an `IndexError` crash when plotting a graph component with zero edges or zero nodes using `wmg.visualise.nx_draw_with_pos_and_attr`. [\#131](https://github.com/mllam/weather-model-graphs/pull/131) @sudhansu-24
 
 ## [v0.3.0](https://github.com/mllam/weather-model-graphs/releases/tag/v0.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `__version__` attribute to the package init
   [\#56](https://github.com/mllam/weather-model-graphs/pull/56) @AdMub
 
+### Fixed
+
+- Fix an `IndexError` crash when plotting a graph component with zero edges or zero nodes using `wmg.visualise.nx_draw_with_pos_and_attr`.
+
 ## [v0.3.0](https://github.com/mllam/weather-model-graphs/releases/tag/v0.3.0)
 
 

--- a/src/weather_model_graphs/visualise/plot_2d.py
+++ b/src/weather_model_graphs/visualise/plot_2d.py
@@ -21,9 +21,21 @@ def nx_draw_with_pos(g, with_labels=False, **kwargs):
 
 def _get_graph_attr_values(g, attr_name, component="edges"):
     if component == "edges":
-        features = list(g.edges(data=True))[0][2].keys()
+        edge_data = list(g.edges(data=True))
+        if len(edge_data) == 0:
+            raise ValueError(
+                f"Cannot colour by edge attribute '{attr_name}' because the "
+                "graph has no edges."
+            )
+        features = edge_data[0][2].keys()
     elif component == "nodes":
-        features = list(g.nodes(data=True))[0][1].keys()
+        node_data = list(g.nodes(data=True))
+        if len(node_data) == 0:
+            raise ValueError(
+                f"Cannot colour by node attribute '{attr_name}' because the "
+                "graph has no nodes."
+            )
+        features = node_data[0][1].keys()
     else:
         raise ValueError(
             f"`component` should be either 'edges' or 'nodes', but got '{component}'"
@@ -141,7 +153,7 @@ def nx_draw_with_pos_and_attr(
     if node_zorder_attr is not None:
         graph = nx_utils.sort_nodes_internally(graph, node_attr=node_zorder_attr)
 
-    if edge_color_attr is not None:
+    if edge_color_attr is not None and graph.number_of_edges() > 0:
         edge_attr_vals = _get_graph_attr_values(
             graph, edge_color_attr, component="edges"
         )
@@ -154,8 +166,10 @@ def nx_draw_with_pos_and_attr(
         kwargs["edge_color"] = edge_attr_vals["values"]
         kwargs["edge_vmin"] = min(edge_attr_vals["values"])
         kwargs["edge_vmax"] = max(edge_attr_vals["values"])
+    elif edge_color_attr is not None:
+        edge_color_attr = None  # nothing to colour
 
-    if node_color_attr is not None:
+    if node_color_attr is not None and graph.number_of_nodes() > 0:
         node_attr_vals = _get_graph_attr_values(
             graph, node_color_attr, component="nodes"
         )
@@ -167,6 +181,8 @@ def nx_draw_with_pos_and_attr(
         kwargs["node_color"] = node_attr_vals["values"]
         kwargs["vmin"] = min(node_attr_vals["values"])
         kwargs["vmax"] = max(node_attr_vals["values"])
+    elif node_color_attr is not None:
+        node_color_attr = None  # nothing to colour
 
     ax = nx_draw_with_pos(
         graph,

--- a/tests/test_graph_plots.py
+++ b/tests/test_graph_plots.py
@@ -64,3 +64,54 @@ def test_plot():
 
     with tempfile.NamedTemporaryFile(suffix=".png") as f:
         fig.savefig(f.name)
+
+
+def test_plot_nodes_only_graph_with_edge_color_attr():
+    """Plotting a graph with nodes but no edges and edge_color_attr should
+    not crash (previously raised IndexError)."""
+    import networkx as nx
+
+    G = nx.DiGraph()
+    G.add_node(0, pos=np.array([1.0, 2.0]), type="mesh")
+    G.add_node(1, pos=np.array([3.0, 4.0]), type="grid")
+
+    # Should silently skip edge colouring, not raise IndexError
+    ax = wmg.visualise.nx_draw_with_pos_and_attr(G, edge_color_attr="len")
+    assert ax is not None
+    plt.close("all")
+
+
+def test_plot_empty_graph_with_node_color_attr():
+    """Plotting a completely empty graph with node_color_attr should not crash."""
+    import networkx as nx
+
+    G = nx.DiGraph()
+
+    ax = wmg.visualise.nx_draw_with_pos_and_attr(G, node_color_attr="type")
+    assert ax is not None
+    plt.close("all")
+
+
+def test_get_graph_attr_values_raises_on_empty_edges():
+    """_get_graph_attr_values should raise a clear ValueError for empty edges."""
+    import networkx as nx
+
+    from weather_model_graphs.visualise.plot_2d import _get_graph_attr_values
+
+    G = nx.DiGraph()
+    G.add_node(0, pos=np.array([1.0, 2.0]))
+
+    with pytest.raises(ValueError, match="no edges"):
+        _get_graph_attr_values(G, "len", component="edges")
+
+
+def test_get_graph_attr_values_raises_on_empty_nodes():
+    """_get_graph_attr_values should raise a clear ValueError for empty nodes."""
+    import networkx as nx
+
+    from weather_model_graphs.visualise.plot_2d import _get_graph_attr_values
+
+    G = nx.DiGraph()
+
+    with pytest.raises(ValueError, match="no nodes"):
+        _get_graph_attr_values(G, "type", component="nodes")


### PR DESCRIPTION
## Describe your changes

guards `wmg.visualise.plot_2d` from crashing with `IndexError` when attempting to apply attribute coloring to empty graph components (zero edges or zero nodes).

when splitting graphs via `filter_graph` or `split_graph_by_edge_attribute`, users often process a dictionary of subgraphs. If a subgraph  contains nodes but no edges (or is completely empty), plotting it with an `edge_color_attr` used to crash inside `_get_graph_attr_values` because it indexed `[0]` on an empty list
 
This PR fixes it by:
1. Adding early-exit guards in `nx_draw_with_pos_and_attr` to gracefully skip coloring when `number_of_edges() == 0` or `number_of_nodes() == 0`.
2. Adding a descriptive `ValueError` inside `_get_graph_attr_values` for when it is called directly on empty graph components.
3. Adding 4 regression tests to `test_graph_plots.py` covering these edge cases.

## Issue Link

solves #130 

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [] I have updated the documentation to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [x] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
