### PR TITLE
fix: correct duplicate coords_crs condition to check graph_crs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Fix duplicate `coords_crs` condition in `create_all_graph_components` that should check `graph_crs`
+  [\#69](https://github.com/mllam/weather-model-graphs/issues/69)
+
 ### Added
 
 - Added a standalone graph consistency checking tool (`wmg.diagnostics.check_graph_consistency`) to ensure structural health, such as verifying all grid nodes successfully connect to the mesh (#42).

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -101,7 +101,7 @@ def create_all_graph_components(
     ), "Grid node coordinates should be given as an array of shape [num_grid_nodes, 2]."
 
     # Translate between coordinate crs and crs to use for graph creation
-    if coords_crs is None and coords_crs is None:
+    if coords_crs is None and graph_crs is None:
         logger.debug(
             "No `coords_crs` given: Assuming `coords` contains in-projection Cartesian coordinates."
         )


### PR DESCRIPTION
## Describe your changes

Fixes a logic bug in `create_all_graph_components()` where `coords_crs` was compared to itself twice instead of checking both `coords_crs` and `graph_crs`. The condition `if coords_crs is None and coords_crs is None` should be `if coords_crs is None and graph_crs is None`.

This caused the XOR branch (for coordinate transformation when only one CRS is provided) to never be reached when `coords_crs=None` and `graph_crs` was set.

## Issue Link

Fixes #69

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [x] I have updated the documentation to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form
- [x] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section reflecting type of change