### PR TITLE
perf: Vectorize KDTree queries and edge insertion in connect_nodes_across_graphs

### DIFF
--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -255,12 +255,15 @@ def connect_nodes_across_graphs(
         Graph containing the nodes in `G_source` and `G_target` and directed edges
         from nodes in `G_source` to nodes in `G_target`
     """
-    source_nodes_list = list(G_source.nodes)
+    source_nodes_list = sorted(G_source.nodes)
     target_nodes_list = list(G_target.nodes)
 
-    # build kd tree for source nodes (e.g. the mesh nodes when constructing m2g)
-    xy_source = np.array([G_source.nodes[node]["pos"] for node in G_source.nodes])
+    # build kd tree for source nodes; order must match source_nodes_list
+    xy_source = np.array([G_source.nodes[n]["pos"] for n in source_nodes_list])
     kdt_s = scipy.spatial.KDTree(xy_source)
+
+    xy_target_all = np.array([G_target.nodes[n]["pos"] for n in target_nodes_list])
+    N_target = len(target_nodes_list)
 
     # Determine method and perform checks once
     # Conditionally define _find_neighbour_node_idxs_in_source_mesh for use in
@@ -399,9 +402,6 @@ def connect_nodes_across_graphs(
     G_connect = networkx.DiGraph()
     G_connect.add_nodes_from(sorted(G_source.nodes(data=True)))
     G_connect.add_nodes_from(sorted(G_target.nodes(data=True)))
-
-    # sort nodes by index
-    source_nodes_list = sorted(G_source.nodes)
 
     # add edges
     for target_node in target_nodes_list:

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -265,9 +265,8 @@ def connect_nodes_across_graphs(
     xy_target_all = np.array([G_target.nodes[n]["pos"] for n in target_nodes_list])
     N_target = len(target_nodes_list)
 
-    # Determine method and perform checks once
-    # Conditionally define _find_neighbour_node_idxs_in_source_mesh for use in
-    # loop later
+    # Validate arguments and run batch KDTree query for the chosen method.
+    # Each branch sets source_indices and target_indices (1-D, aligned).
     if method == "containing_rectangle":
         if (
             max_dist is not None

--- a/src/weather_model_graphs/create/base.py
+++ b/src/weather_model_graphs/create/base.py
@@ -326,10 +326,9 @@ def connect_nodes_across_graphs(
             raise Exception(
                 "to use `nearest_neighbour` you should not set `max_dist`, `rel_max_dist`or `max_num_neighbours`"
             )
-
-        def _find_neighbour_node_idxs_in_source_mesh(xy_target):
-            neigh_idx = kdt_s.query(xy_target, 1)[1]
-            return [neigh_idx]
+        # Batch query: shape (N_target,)
+        source_indices = kdt_s.query(xy_target_all, 1)[1]
+        target_indices = np.arange(N_target)
 
     elif method == "nearest_neighbours":
         if max_num_neighbours is None:
@@ -340,10 +339,10 @@ def connect_nodes_across_graphs(
             raise Exception(
                 "to use `nearest_neighbours` you should not set `max_dist` or `rel_max_dist`"
             )
-
-        def _find_neighbour_node_idxs_in_source_mesh(xy_target):
-            neigh_idxs = kdt_s.query(xy_target, max_num_neighbours)[1]
-            return neigh_idxs
+        # Batch query: shape (N_target, max_num_neighbours)
+        neigh_idxs = kdt_s.query(xy_target_all, max_num_neighbours)[1]
+        source_indices = neigh_idxs.ravel()
+        target_indices = np.repeat(np.arange(N_target), max_num_neighbours)
 
     elif method == "within_radius":
         if max_num_neighbours is not None:
@@ -392,38 +391,37 @@ def connect_nodes_across_graphs(
                 "to use `witin_radius` method you shold set `max_dist` or `rel_max_dist"
             )
 
-        def _find_neighbour_node_idxs_in_source_mesh(xy_target):
-            neigh_idxs = kdt_s.query_ball_point(xy_target, query_dist)
-            return neigh_idxs
+        # Batch query: ragged because each target may have different neighbour count
+        neigh_idxs_ragged = kdt_s.query_ball_point(xy_target_all, query_dist)
+        counts = [len(row) for row in neigh_idxs_ragged]
+        target_indices = np.repeat(np.arange(N_target), counts)
+        nonempty_rows = [row for row in neigh_idxs_ragged if len(row) > 0]
+        source_indices = (
+            np.concatenate(nonempty_rows).astype(int)
+            if nonempty_rows
+            else np.array([], dtype=int)
+        )
 
     else:
         raise NotImplementedError(method)
+
+    # Vectorized edge attribute computation
+    xy_src = xy_source[source_indices]        # (N_edges, 2)
+    xy_tgt = xy_target_all[target_indices]    # (N_edges, 2)
+    vdiffs = xy_src - xy_tgt                  # (N_edges, 2)
+    lengths = np.linalg.norm(vdiffs, axis=1)  # (N_edges,)
 
     G_connect = networkx.DiGraph()
     G_connect.add_nodes_from(sorted(G_source.nodes(data=True)))
     G_connect.add_nodes_from(sorted(G_target.nodes(data=True)))
 
-    # add edges
-    for target_node in target_nodes_list:
-        xy_target = G_target.nodes[target_node]["pos"]
-        neigh_idxs = _find_neighbour_node_idxs_in_source_mesh(xy_target)
-        for i in neigh_idxs:
-            source_node = source_nodes_list[i]
-            # add edge from source to target
-            G_connect.add_edge(source_node, target_node)
-            d = np.sqrt(
-                np.sum(
-                    (
-                        G_connect.nodes[source_node]["pos"]
-                        - G_connect.nodes[target_node]["pos"]
-                    )
-                    ** 2
-                )
-            )
-            G_connect.edges[source_node, target_node]["len"] = d
-            G_connect.edges[source_node, target_node]["vdiff"] = (
-                G_connect.nodes[source_node]["pos"]
-                - G_connect.nodes[target_node]["pos"]
-            )
+    G_connect.add_edges_from(
+        (
+            source_nodes_list[si],
+            target_nodes_list[ti],
+            {"len": float(lengths[e]), "vdiff": vdiffs[e]},
+        )
+        for e, (si, ti) in enumerate(zip(source_indices, target_indices))
+    )
 
     return G_connect

--- a/tests/test_connect_nodes_vectorized.py
+++ b/tests/test_connect_nodes_vectorized.py
@@ -50,12 +50,7 @@ def test_nearest_neighbour_one_edge_per_target():
     _assert_edge_attrs_valid(G, source, target)
 
 
-@pytest.mark.parametrize("k", [
-    pytest.param(1, marks=pytest.mark.xfail(
-        strict=True, reason="k=1 triggers scalar-vs-array bug in serial loop; fixed by vectorization"
-    )),
-    3, 4, 8,
-])
+@pytest.mark.parametrize("k", [1, 3, 4, 8])
 def test_nearest_neighbours_at_most_k_per_target(k):
     source, target = _make_source_target()
     G = connect_nodes_across_graphs(

--- a/tests/test_connect_nodes_vectorized.py
+++ b/tests/test_connect_nodes_vectorized.py
@@ -1,9 +1,10 @@
 # tests/test_connect_nodes_vectorized.py
 import numpy as np
 import pytest
+
+import tests.utils as test_utils
 import weather_model_graphs as wmg
 from weather_model_graphs.create.base import connect_nodes_across_graphs
-import tests.utils as test_utils
 
 
 def _make_source_target():
@@ -49,7 +50,12 @@ def test_nearest_neighbour_one_edge_per_target():
     _assert_edge_attrs_valid(G, source, target)
 
 
-@pytest.mark.parametrize("k", [3, 4, 8])
+@pytest.mark.parametrize("k", [
+    pytest.param(1, marks=pytest.mark.xfail(
+        strict=True, reason="k=1 triggers scalar-vs-array bug in serial loop; fixed by vectorization"
+    )),
+    3, 4, 8,
+])
 def test_nearest_neighbours_at_most_k_per_target(k):
     source, target = _make_source_target()
     G = connect_nodes_across_graphs(
@@ -58,8 +64,9 @@ def test_nearest_neighbours_at_most_k_per_target(k):
 
     for node in target.nodes:
         preds = list(G.predecessors(node))
-        assert len(preds) <= k, (
-            f"Target {node} has {len(preds)} predecessors, expected <= {k}"
+        # source has 25 nodes >= max k=8, so every target always gets exactly k neighbours
+        assert len(preds) == k, (
+            f"Target {node} has {len(preds)} predecessors, expected exactly {k}"
         )
         for p in preds:
             assert p in source.nodes
@@ -73,6 +80,7 @@ def test_within_radius_all_edges_within_dist(max_dist):
     G = connect_nodes_across_graphs(
         source, target, method="within_radius", max_dist=max_dist
     )
+    assert G.number_of_edges() > 0, f"Expected edges with max_dist={max_dist}, got 0"
 
     for u, v, data in G.edges(data=True):
         assert data["len"] <= max_dist + 1e-10, (
@@ -93,5 +101,4 @@ def test_within_radius_rel_max_dist():
 def test_containing_rectangle_nodes_preserved():
     source, target = _make_source_target()
     G = connect_nodes_across_graphs(source, target, method="containing_rectangle")
-    assert set(G.nodes) == set(source.nodes) | set(target.nodes)
     _assert_edge_attrs_valid(G, source, target)

--- a/tests/test_connect_nodes_vectorized.py
+++ b/tests/test_connect_nodes_vectorized.py
@@ -57,6 +57,9 @@ def test_nearest_neighbours_at_most_k_per_target(k):
         source, target, method="nearest_neighbours", max_num_neighbours=k
     )
 
+    # Precondition: fixture must have enough source nodes for all targets to get exactly k
+    assert source.number_of_nodes() >= k, "fixture too small; test precondition violated"
+
     for node in target.nodes:
         preds = list(G.predecessors(node))
         # source has 25 nodes >= max k=8, so every target always gets exactly k neighbours

--- a/tests/test_connect_nodes_vectorized.py
+++ b/tests/test_connect_nodes_vectorized.py
@@ -1,0 +1,97 @@
+# tests/test_connect_nodes_vectorized.py
+import numpy as np
+import pytest
+import weather_model_graphs as wmg
+from weather_model_graphs.create.base import connect_nodes_across_graphs
+import tests.utils as test_utils
+
+
+def _make_source_target():
+    """Small deterministic mesh source + grid target for fast tests."""
+    xy = test_utils.create_fake_xy(N=10)
+    source = wmg.create.mesh.create_single_level_2d_mesh_graph(xy=xy, nx=5, ny=5)
+    target = wmg.create.grid.create_grid_graph_nodes(xy)
+    return source, target
+
+
+def _assert_edge_attrs_valid(G, G_source, G_target):
+    """Common invariants for all connection methods."""
+    assert set(G.nodes) == set(G_source.nodes) | set(G_target.nodes)
+
+    for u, v, data in G.edges(data=True):
+        assert u in G_source.nodes, f"Edge source {u} not in G_source"
+        assert v in G_target.nodes, f"Edge target {v} not in G_target"
+        assert "len" in data, "Missing 'len' attribute"
+        assert "vdiff" in data, "Missing 'vdiff' attribute"
+
+        pos_u = np.array(G.nodes[u]["pos"])
+        pos_v = np.array(G.nodes[v]["pos"])
+        expected_vdiff = pos_u - pos_v
+        expected_len = np.linalg.norm(expected_vdiff)
+
+        assert np.isclose(data["len"], expected_len, atol=1e-10), (
+            f"Edge ({u},{v}): len={data['len']}, expected={expected_len}"
+        )
+        assert np.allclose(data["vdiff"], expected_vdiff, atol=1e-10), (
+            f"Edge ({u},{v}): vdiff={data['vdiff']}, expected={expected_vdiff}"
+        )
+
+
+def test_nearest_neighbour_one_edge_per_target():
+    source, target = _make_source_target()
+    G = connect_nodes_across_graphs(source, target, method="nearest_neighbour")
+
+    for node in target.nodes:
+        preds = list(G.predecessors(node))
+        assert len(preds) == 1, f"Target {node} has {len(preds)} predecessors, expected 1"
+        assert preds[0] in source.nodes
+
+    _assert_edge_attrs_valid(G, source, target)
+
+
+@pytest.mark.parametrize("k", [3, 4, 8])
+def test_nearest_neighbours_at_most_k_per_target(k):
+    source, target = _make_source_target()
+    G = connect_nodes_across_graphs(
+        source, target, method="nearest_neighbours", max_num_neighbours=k
+    )
+
+    for node in target.nodes:
+        preds = list(G.predecessors(node))
+        assert len(preds) <= k, (
+            f"Target {node} has {len(preds)} predecessors, expected <= {k}"
+        )
+        for p in preds:
+            assert p in source.nodes
+
+    _assert_edge_attrs_valid(G, source, target)
+
+
+@pytest.mark.parametrize("max_dist", [1.5, 3.0, 6.0])
+def test_within_radius_all_edges_within_dist(max_dist):
+    source, target = _make_source_target()
+    G = connect_nodes_across_graphs(
+        source, target, method="within_radius", max_dist=max_dist
+    )
+
+    for u, v, data in G.edges(data=True):
+        assert data["len"] <= max_dist + 1e-10, (
+            f"Edge ({u},{v}) len={data['len']} exceeds max_dist={max_dist}"
+        )
+
+    _assert_edge_attrs_valid(G, source, target)
+
+
+def test_within_radius_rel_max_dist():
+    source, target = _make_source_target()
+    G = connect_nodes_across_graphs(
+        source, target, method="within_radius", rel_max_dist=1.0
+    )
+    _assert_edge_attrs_valid(G, source, target)
+
+
+def test_containing_rectangle_nodes_preserved():
+    source, target = _make_source_target()
+    G = connect_nodes_across_graphs(source, target, method="containing_rectangle")
+    assert set(G.nodes) == set(source.nodes) | set(target.nodes)
+    _assert_edge_attrs_valid(G, source, target)


### PR DESCRIPTION
## Describe your changes

Replaces per-target Python loop with batch NumPy/SciPy operations in `connect_nodes_across_graphs`. Also fixes a latent bug: KDTree was built from `list(G_source.nodes)` but indices resolved against `sorted(G_source.nodes)`, connecting the wrong source node when dict iteration order != sort order.

**Motivation:** Called for every edge type (g2m, m2g, m2m). Old code issued one KDTree query per target node and computed edge attributes scalar-by-scalar. Batch queries + vectorized NumPy ops eliminate the Python loop entirely.

**Changes:**
- Batch KDTree query over all targets at once (all three methods)
- `nearest_neighbours`: `.ravel()` + `np.repeat` for flat index arrays
- `within_radius`: concatenate ragged `query_ball_point` results
- Vectorized `vdiff`/`len` via `np.linalg.norm` across all edges
- `source_nodes_list` sorted before KDTree build, fixing index mismatch
- Removes `_find_neighbour_node_idxs_in_source_mesh` closure

---

## Performance Benchmarks

Benchmark script: [wmg#117](https://github.com/mllam/weather-model-graphs/pull/117).

| Archetype | Before | After | Speedup |
|---|---|---|---|
| `graphcast` | ~58 s | ~19 s | **~3.1x** |
| `keisler` | ~52 s | ~23 s | **~2.3x** |
| `oskarsson_hierarchical` | ~38 s | ~18 s | **~2.1x** |

### Scaling plots

**graphcast**

| Before | After |
|---|---|
| <img width="1000" height="600" alt="scaling_before_graphcast" src="https://github.com/user-attachments/assets/4656099d-70d5-4669-ac39-6bbfa589be3d" /> | <img width="1000" height="600" alt="scaling_after_graphcast" src="https://github.com/user-attachments/assets/0112bb50-a5ec-4c1b-a4ec-5769572c5958" /> |

**keisler**

| Before | After |
|---|---|
| <img width="1000" height="600" alt="scaling_before_keisler" src="https://github.com/user-attachments/assets/1a3ca74f-94eb-4806-8e3e-695782131cb5" /> | <img width="1000" height="600" alt="scaling_after_keisler" src="https://github.com/user-attachments/assets/d9e378a8-8e8a-4f92-9954-7dbd9ea92e86" /> |

**oskarsson_hierarchical**

| Before | After |
|---|---|
| <img width="1000" height="600" alt="scaling_before_oskarsson" src="https://github.com/user-attachments/assets/6c4f6141-20b6-49f2-a040-c59d9ff32f88" /> | <img width="1000" height="600" alt="scaling_after_oskarsson" src="https://github.com/user-attachments/assets/e9cd4619-0c89-478e-91c4-9afaea65b402" /> |

---

## Issue Link
Closes #138

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change
- [ ] 📖 Documentation

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the documentation to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form))
- [x] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG:
  - *added*: new functionality
  - *changed*: default behaviour changed
  - *fixes*: bug fix

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog
- Once ready, squash commits and merge.